### PR TITLE
removed plantsdb call + replaced codes with usdaCodes

### DIFF
--- a/src/components/edit/Interactions.jsx
+++ b/src/components/edit/Interactions.jsx
@@ -39,7 +39,7 @@ const EditInteractions = (props) => {
       setData({ ...data, selectedOak: undefined, hiOak: undefined });
       return;
     }
-    getOak(option.value, false)
+    getOak(option.value)
       .then(oak => setData({ ...data, selectedOak: option, hiOak: oak }));
   }
 

--- a/src/components/oaks/Oak.jsx
+++ b/src/components/oaks/Oak.jsx
@@ -59,7 +59,7 @@ const Oak = () => {
         <CalPhotos genus={oak.genus} species={oak.species} />
         <p>{' '}</p>
         <p>
-          <b>Range map:</b> <a href={`https://plants.usda.gov/home/plantProfile?symbol=${oak.code}`} target="_blank">Search USDA Plants Database</a>
+          <b>Range map:</b> <a href={`https://plants.usda.gov/home/plantProfile?symbol=${oak.usdaCode}`} target="_blank">Search USDA Plants Database</a>
         </p>
         { oak.notes ? <Notes notes={oak.notes} /> : null }
       </div>

--- a/src/services/oaks.js
+++ b/src/services/oaks.js
@@ -12,25 +12,8 @@ export const getAllOaks = () => {
     });
 };
 
-export const getPlantCode = (oak) => {
-  const qstring = `Genus=${oak.genus}&Species=${oak.species}&Variety=${oak.subSpecies}&limit=1`;
-  return fetch(`http://plantsdb.xyz/search?${qstring}`)
-    .then(checkResponse)
-    .then(res => res.data[0].Accepted_Symbol_x)
-    .then((code) => {
-      oak.code = code;
-      return oak;
-    })
-    .catch((err) => {
-      console.warn(err);
-      oak.code = '';
-      return oak;
-    });
-};
-
-export const getOak = (id, includePlantCode = true) => fetch(`${url}/oaks/${id}`, { mode: 'cors' })
+export const getOak = (id) => fetch(`${url}/oaks/${id}`, { mode: 'cors' })
   .then(checkResponse)
-  .then(oak => includePlantCode ? getPlantCode(oak) : oak)
   .then((oak) => {
     oak.notes = bufferToString(oak.notes).replace(/ -/g, '\n-');
     return oak;


### PR DESCRIPTION
Renamed oak.code to oak.usdaCode  Deleted function that previously called now defunct USDA plants database to get oak.code. we deleted references to the oak.code where it is no longer used since the function was deleted. 