### PR TITLE
draft create links to online fieldguide

### DIFF
--- a/src/components/agents/Agent.jsx
+++ b/src/components/agents/Agent.jsx
@@ -9,6 +9,7 @@ import {
   AgentTaxonomy,
   DefaultCitation,
   AuditRecord,
+  BookLink,
 } from '../shared/partials';
 import { Spinner } from '../shared/shapes';
 import CAMap from '../shared/Map';
@@ -70,6 +71,7 @@ const Agent = () => {
             genus={agent.primarySynonym?.genus}
             species={agent.primarySynonym?.species}
           />
+          {agent.bookLink ? <BookLink bookLink={agent.bookLink} /> : null}
           <p />
           <Synonyms synonyms={agent.otherSynonyms} />
           <p />

--- a/src/components/edit/Agents.jsx
+++ b/src/components/edit/Agents.jsx
@@ -260,6 +260,7 @@ const EditAgents = (props) => {
             title="Link to field guide chapter"
             value={selectedAgent.bookLink}
             name="bookLink"
+            onChange={onInputChange}
           />
           <TextArea
             title="Original coda record (noneditable field)"

--- a/src/components/edit/constants.ts
+++ b/src/components/edit/constants.ts
@@ -33,3 +33,5 @@ export const PRIMARY = [
   'Secondary (attacks stressed, injured, or compromised tissue)',
   '',
 ];
+
+export const bookHost = 'https://phytosphere.com/fieldguide/';

--- a/src/components/interactions/InteractionPage.jsx
+++ b/src/components/interactions/InteractionPage.jsx
@@ -11,6 +11,7 @@ import {
   Synonyms,
   Notes,
   CalPhotos,
+  BookLink,
   DefaultCitation,
   AuditRecord,
 } from '../shared/partials';
@@ -122,6 +123,7 @@ const InteractionPage = () => {
           <p />
           {agent.commonName && <CommonName commonName={agent.commonName} />}
           <CalPhotos genus={agent.genus} species={agent.species} />
+          {agent.bookLink ? <BookLink bookLink={agent.bookLink} /> : null}
           <p />
           <AgentTaxonomy agent={agent} />
           <p />

--- a/src/components/shared/partials.jsx
+++ b/src/components/shared/partials.jsx
@@ -88,6 +88,17 @@ CalPhotos.propTypes = {
   species: PropTypes.string,
 };
 
+export const BookLink = ({ bookLink }) => (
+  <div style={{ marginLeft: '57px' }}>
+    <a href={`${bookLink}`} target="_blank">
+      Field Guide to Insects and Diseases of California Oaks
+    </a>
+  </div>
+);
+BookLink.propTypes = {
+  bookLink: PropTypes.string,
+};
+
 export const AgentTaxonomy = ({ agent }) => (
   <div className="taxonomy">
     <div>

--- a/src/components/shared/partials.jsx
+++ b/src/components/shared/partials.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { bookHost } from '../edit/constants';
 
 export const DefaultCitation = () => (
   <div>
@@ -90,7 +91,7 @@ CalPhotos.propTypes = {
 
 export const BookLink = ({ bookLink }) => (
   <div style={{ marginLeft: '57px' }}>
-    <a href={`${bookLink}`} target="_blank">
+    <a href={`${bookHost}${bookLink}`} target="_blank">
       Field Guide to Insects and Diseases of California Oaks
     </a>
   </div>


### PR DESCRIPTION
Draft of added links to the epub. But- is there a way I can pull the host domain name into a variable so that it can be used as the link? For example, right now https://phytosphere.com/fieldguide/Acorninsect.html#Filbertworm is stored in the database as the link to the fieldguide, but could it be fieldguide/Acorninsect.html#Filbertworm and then served as const hostDomain = https://phytosphere.com/  and the link would become hostDomain + bookLink where https://phytosphere.com/ is somehow pulled from existing code base?  (At least in client I didn't see a way to get it.) So that when we hand this off to Forest Pest council, their website name will show as the hostDomain and all those links won't have to be edited to make the links to the fieldguide work. 